### PR TITLE
documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,34 +166,6 @@ MetaTrader 4 can be downloaded either from the broker's website or directly from
             MetaEditor
         </a>
     </td>
-    <td> </td>
-</tr>
-
-<tr>
-    <td nowrap>
-        <a href="http://www.rosasurfer.com/.mt4/1376/terminal.exe"><img src="https://user-images.githubusercontent.com/12749283/57028778-a698fd00-6c48-11e9-89f1-0c4d669dbe1d.png" title="download" alt="download" border="0">
-            Terminal build 1376
-        </a>
-    </td>
-    <td nowrap>
-        <a href="http://www.rosasurfer.com/.mt4/1376/metaeditor.exe"><img src="https://user-images.githubusercontent.com/12749283/57028778-a698fd00-6c48-11e9-89f1-0c4d669dbe1d.png" title="download" alt="download" border="0">
-            MetaEditor
-        </a>
-    </td>
-    <td> </td>
-</tr>
-
-<tr>
-    <td nowrap>
-        <a href="http://www.rosasurfer.com/.mt4/1370/terminal.exe"><img src="https://user-images.githubusercontent.com/12749283/57028778-a698fd00-6c48-11e9-89f1-0c4d669dbe1d.png" title="download" alt="download" border="0">
-            Terminal build 1370
-        </a>
-    </td>
-    <td nowrap>
-        <a href="http://www.rosasurfer.com/.mt4/1370/metaeditor.exe"><img src="https://user-images.githubusercontent.com/12749283/57028778-a698fd00-6c48-11e9-89f1-0c4d669dbe1d.png" title="download" alt="download" border="0">
-            MetaEditor
-        </a>
-    </td>
     <td nowrap> oldest build supported by MetaQuotes </td>
 </tr>
 
@@ -267,6 +239,8 @@ MetaTrader 4 can be downloaded either from the broker's website or directly from
 
 ### MetaTrader 4 News
 
+###### December 2023:
+- MetaQuotes stops supporting terminals older than build 1380.
 ###### May 2023:
 - MetaQuotes stops supporting terminals older than build 1370.
 


### PR DESCRIPTION
Starting from December 1, 2023: MT4 minimum supported version is `1380`